### PR TITLE
Add /random endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ node index.js
 
 The application listens on port `3000` by default.
 
+### Endpoints
+
+- `GET /` - returns "Hello, world!"
+- `GET /random` - returns a JSON object with a random number
+
 ## Docker
 
 You can build and run the application using Docker.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ app.get('/', (req, res) => {
     res.send('Hello, world!');
 });
 
+// Return a random number between 0 and 1
+app.get('/random', (req, res) => {
+    res.json({ number: Math.random() });
+});
+
 app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add new `/random` route that returns a random number
- document the new endpoint in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f3a5b7aec832cbea0d7530aaca8bc